### PR TITLE
Fixed broken "Edit This Page" link

### DIFF
--- a/book.json
+++ b/book.json
@@ -3,7 +3,7 @@
   "plugins": ["edit-link", "github"],
   "pluginsConfig": {
     "edit-link": {
-      "base": "https://github.com/jcc/blog-manual/",
+      "base": "https://github.com/jcc/blog-manual/blob/master/",
       "label": "Edit This Page"
     },
     "github": {


### PR DESCRIPTION
The current link destination, e.g. https://github.com/jcc/blog-manual/en/installation.md, results in a 404